### PR TITLE
Add configurable similarity threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,6 @@ A interface permite pesquisar profissionais por profissão e localização. Os d
 utilizados são apenas exemplos fictícios para demonstração. Os exemplos agora
 estão reunidos no arquivo `dados.py`, totalizando mais de 100 registros para
 facilitar testes.
+
+É possível definir a porcentagem mínima de similaridade utilizada nos filtros
+"soft" por meio do campo **Similaridade (%)** da interface.


### PR DESCRIPTION
## Summary
- allow adjusting similarity threshold when filtering professionals
- add Similaridade (%) field with numeric validation
- document soft-filter similarity option in README

## Testing
- `python -m py_compile dados.py gui.py`

------
https://chatgpt.com/codex/tasks/task_e_684b26e999908324b6167aea661b80e1