### PR TITLE
Enable Enter key to perform search

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -338,6 +338,11 @@ def criar_interface():
     )
     botao.grid(column=0, row=12, columnspan=3, pady=5)
 
+    def _enter(event):
+        botao.invoke()
+
+    root.bind("<Return>", _enter)
+
     root.mainloop()
 
 


### PR DESCRIPTION
## Summary
- bind Return key in `criar_interface` to trigger the search button

## Testing
- `python -m py_compile gui.py dados.py`

------
https://chatgpt.com/codex/tasks/task_e_684b2915a89c8324bc3965241001c34e