### PR TITLE
Add Excel data import with sample generation

### DIFF
--- a/dados.py
+++ b/dados.py
@@ -1,3 +1,11 @@
+from typing import Dict, List
+
+try:
+    from openpyxl import Workbook, load_workbook
+except Exception:  # pragma: no cover - openpyxl pode não estar disponível
+    Workbook = None
+    load_workbook = None
+
 PROFISSIONAIS = [
     {
         "nome": "Fulano",
@@ -111,3 +119,78 @@ def _gerar_profissionais_teste():
 
 
 _gerar_profissionais_teste()
+
+
+# ---------------------------------------------------------------------------
+# Utilidades para arquivo Excel
+# ---------------------------------------------------------------------------
+
+
+REQUIRED_COLUMNS = [
+    "nome",
+    "titulo",
+    "pais",
+    "estado",
+    "cidade",
+    "setor",
+    "senioridade",
+    "skills",
+    "empresa",
+    "formacao",
+    "certificacoes",
+]
+
+
+def salvar_excel(path: str) -> None:
+    """Salva um arquivo Excel com os 100 primeiros registros fictícios."""
+
+    if Workbook is None:  # pragma: no cover - dependencia opcional
+        raise ImportError("openpyxl não está disponível")
+
+    wb = Workbook()  # type: ignore[call-arg]
+    ws = wb.active  # type: ignore[assignment]
+    ws.append(REQUIRED_COLUMNS)  # type: ignore[operator]
+
+    for p in PROFISSIONAIS[:100]:
+        row = []
+        for col in REQUIRED_COLUMNS:
+            val = p.get(col, "")
+            if isinstance(val, list):
+                val = ", ".join(val)
+            row.append(val)
+        ws.append(row)  # type: ignore[operator]
+
+    wb.save(path)  # type: ignore[operator]
+
+
+def carregar_excel(path: str) -> List[Dict]:
+    """Carrega profissionais a partir de um arquivo Excel."""
+
+    if load_workbook is None:  # pragma: no cover - dependencia opcional
+        raise ImportError("openpyxl não está disponível")
+
+    wb = load_workbook(path)  # type: ignore[call-arg]
+    ws = wb.active  # type: ignore[assignment]
+
+    headers = [c.value for c in next(ws.iter_rows(min_row=1, max_row=1))]  # type: ignore[operator]
+    if not all(col in headers for col in REQUIRED_COLUMNS):
+        raise ValueError("colunas ausentes")
+
+    indices = {h: headers.index(h) for h in REQUIRED_COLUMNS}
+    dados: List[Dict] = []
+    for row in ws.iter_rows(min_row=2, values_only=True):  # type: ignore[operator]
+        registro = {}
+        for col in REQUIRED_COLUMNS:
+            idx = indices[col]
+            val = row[idx] if idx < len(row) else None
+            if col in {"skills", "certificacoes"}:
+                if isinstance(val, str):
+                    val = [v.strip() for v in val.split(",") if v.strip()]
+                elif val is None:
+                    val = []
+                else:
+                    val = list(val) if isinstance(val, (list, tuple)) else [val]
+            registro[col] = val
+        dados.append(registro)
+
+    return dados


### PR DESCRIPTION
## Summary
- generate Excel datasets using `salvar_excel`
- load data from Excel via `carregar_excel`
- prompt user for Excel file on startup and create a sample file if needed

## Testing
- `ruff check . --fix`
- `black . --quiet`
- `isort . --profile black`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b33b166f083248dc25e10768031bb